### PR TITLE
Fix Waypoint Manager tries never being reset.

### DIFF
--- a/src/main/kotlin/com/jramsay/way2wayfabric/Way2WayFabric.kt
+++ b/src/main/kotlin/com/jramsay/way2wayfabric/Way2WayFabric.kt
@@ -124,7 +124,7 @@ class MapWatcher {
     }
 
     fun givenUp(): Boolean {
-        return count > 20
+        return count > 24
     }
 
     @Synchronized
@@ -152,6 +152,7 @@ class MapWatcher {
             it(mgr)
         }
         deferred.clear()
+        count = 0
         running = false
     }
 }


### PR DESCRIPTION
Increase try count, set try count to 0 if successfully started.